### PR TITLE
Updated usage of collections.Iterable to work with python 3.8+

### DIFF
--- a/modules/datasources/datasources.py
+++ b/modules/datasources/datasources.py
@@ -118,7 +118,7 @@ def generate_datasource_md(datasource, side_menu_data, side_menu_mobile_view_dat
         if datasource.get("x_mitre_version"):
             data["version"] = datasource["x_mitre_version"]
 
-        if isinstance(datasource.get("x_mitre_contributors"), collections.Iterable):
+        if isinstance(datasource.get("x_mitre_contributors"), collections.abc.Iterable):
             data["contributors_list"] = datasource["x_mitre_contributors"]
 
         if datasource.get("description"):

--- a/modules/groups/groups.py
+++ b/modules/groups/groups.py
@@ -115,7 +115,7 @@ def generate_group_md(group, side_menu_data, side_menu_mobile_view_data, notes):
         if group.get("x_mitre_version"):
             data["version"] = group["x_mitre_version"]
 
-        if isinstance(group.get("x_mitre_contributors"), collections.Iterable):
+        if isinstance(group.get("x_mitre_contributors"), collections.abc.Iterable):
             data["contributors_list"] = group["x_mitre_contributors"]
 
         # Get initial reference list
@@ -173,7 +173,7 @@ def generate_group_md(group, side_menu_data, side_menu_mobile_view_data, notes):
 
         data["citations"] = reference_list
 
-        if isinstance(group.get("aliases"), collections.Iterable):
+        if isinstance(group.get("aliases"), collections.abc.Iterable):
             data["aliases_list"] = group["aliases"][1:]
 
         data["versioning_feature"] = site_config.check_versions_module()
@@ -212,7 +212,7 @@ def get_groups_table_data(group_list):
                 if group.get("x_mitre_deprecated"):
                     row["deprecated"] = True
 
-            if isinstance(group.get("aliases"), collections.Iterable):
+            if isinstance(group.get("aliases"), collections.abc.Iterable):
                 row["aliases_list"] = group["aliases"][1:]
 
             groups_table_data.append(row)

--- a/modules/software/software.py
+++ b/modules/software/software.py
@@ -173,15 +173,15 @@ def generate_software_md(software, side_menu_data, side_menu_mobile_view_data, n
         data["groups"] = get_groups_using_software(software, reference_list)
 
         # Get aliases list
-        if isinstance(software.get("x_mitre_aliases"), collections.Iterable):
+        if isinstance(software.get("x_mitre_aliases"), collections.abc.Iterable):
             data["aliases_list"] = software["x_mitre_aliases"][1:]
 
         # Get contributors
-        if isinstance(software.get("x_mitre_contributors"), collections.Iterable):
+        if isinstance(software.get("x_mitre_contributors"), collections.abc.Iterable):
             data["contributors_list"] = software["x_mitre_contributors"]
 
         # Get platform list
-        if isinstance(software.get("x_mitre_platforms"), collections.Iterable):
+        if isinstance(software.get("x_mitre_platforms"), collections.abc.Iterable):
             data["platform_list"] = software["x_mitre_platforms"]
 
         data["citations"] = reference_list
@@ -218,7 +218,7 @@ def get_software_table_data(software_list):
             if attack_id:
                 row["id"] = attack_id
 
-            if isinstance(software.get("x_mitre_aliases"), collections.Iterable):
+            if isinstance(software.get("x_mitre_aliases"), collections.abc.Iterable):
                 row["aliases_list"] = software["x_mitre_aliases"][1:]
 
             software_table_data.append(row)


### PR DESCRIPTION
Python 3.8+ deprecated the usage of `collections.Iterable` for `collections.abc.Iterable`, so this PR updates this usage accordingly. Otherwise, running the current `master` branch will break on python 3.8_. 