### PR TITLE
Add Support for Mobile to the Data Sources Sidebar

### DIFF
--- a/attack-theme/static/scripts/filter/filter.js
+++ b/attack-theme/static/scripts/filter/filter.js
@@ -115,6 +115,31 @@ function filterTables(switchID, switchID2) {
             }
         }
     }
+
+    // Determine if any of the associated techniques are visible
+    var techniqueObjects = $('.technique');
+    var techniquesVisible = false;
+    for (let techniqueObject of techniqueObjects) {
+        var display = techniqueObject.style.display;
+        if (display.length === 0) {
+            techniquesVisible = true;
+        }
+    }
+
+    // Only show the message if all the associated techniques are hidden
+    var messageObjects = $('.no-techniques-in-data-source-message');
+    if (messageObjects.length > 0) {
+        for (i in messageObjects) {
+            if (messageObjects[i].style) {
+                if (techniquesVisible) {
+                    messageObjects[i].style.display = "none";
+                } else {
+                    messageObjects[i].style.display = "";
+                }
+            }
+        }
+    }
+
     // Update session storage
     sessionStorage.setItem('filter', includedDomains);
 }

--- a/attack-theme/templates/macros/navigation.html
+++ b/attack-theme/templates/macros/navigation.html
@@ -28,6 +28,10 @@ Notes:
             <label class="custom-control-label" for="enterpriseSwitch">Enterprise</label>
         </div>
         <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="mobileSwitch" onchange="filterTables(mobileSwitch, enterpriseSwitch)">
+            <label class="custom-control-label" for="mobileSwitch">Mobile</label>
+        </div>
+        <div class="custom-control custom-switch">
             <input type="checkbox" class="custom-control-input" id="icsSwitch" onchange="filterTables(icsSwitch, enterpriseSwitch)">
             <label class="custom-control-label" for="icsSwitch">ICS</label>
         </div>

--- a/modules/datasources/templates/datasource.html
+++ b/modules/datasources/templates/datasource.html
@@ -143,6 +143,11 @@
                 
                         {% if parsed.datacomponents_list %}
                             <h2 class="pt-3" id="datacomponents">Data Components</h2>
+                            <div class="row no-techniques-in-data-source-message" style="display: none">
+                                <div class="col-md-12 description-body">
+                                    <p>This data source does not have any techniques in the selected domain(s)</p>
+                                </div>
+                            </div>
                             <div class="row">
                                 {% for datacomponent in parsed.datacomponents_list %}
                                     <div class="col-md-12 section-view {% for domain in datacomponent.domains %}{{domain}} {% endfor %}">

--- a/modules/software/software.py
+++ b/modules/software/software.py
@@ -245,7 +245,7 @@ def get_groups_using_software(software, reference_list):
         }
 
     groups = []
-    seen_attack_ids = set()
+    seen_attack_ids = {}
 
     if groups_using_software:
         # Get name, id of group
@@ -268,7 +268,7 @@ def get_groups_using_software(software, reference_list):
                     row["descr"] = group["relationship"]["description"]
                     reference_list = util.buildhelpers.update_reference_list(reference_list, group["relationship"])
 
-                seen_attack_ids.add(attack_id)
+                seen_attack_ids[attack_id] = True
                 groups.append(row)
 
     if groups_attributed_to_campaigns["campaigns"].get(software.get("id")):
@@ -304,7 +304,7 @@ def get_groups_using_software(software, reference_list):
                         if descr:
                             row["descr"] = descr
 
-                        seen_attack_ids.add(attack_id)
+                        seen_attack_ids[attack_id] = True
                         groups.append(row)
 
     return groups

--- a/modules/util/buildhelpers.py
+++ b/modules/util/buildhelpers.py
@@ -133,9 +133,12 @@ def get_reference_set(reflist):
     """This function retrieves the unique set of references in the given list of descriptions and 
        returns them in string format to be displayed as citations."""
     p = re.compile("\(Citation: (.*?)\)")
-    citations = set()
+    citations = {}
     for c in reflist:
-        citations.update(p.findall(c))
+        citations_in_ref = p.findall(c)
+        for citation in citations_in_ref:
+            if citation not in citations:
+                citations[citation] = True
     refs = [f"(Citation: {c})" for c in citations]
     return ''.join(refs)
 

--- a/modules/util/relationshiphelpers.py
+++ b/modules/util/relationshiphelpers.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 from itertools import chain
 
 from loguru import logger
@@ -21,7 +22,7 @@ def get_related(srcs, src_type, rel_type, target_type, reverse=False):
         reverse: build reverse mapping of target to source
     """
 
-    relationships = query_all(
+    relationships_with_dups = query_all(
         srcs,
         [
             Filter("type", "=", "relationship"),
@@ -29,6 +30,13 @@ def get_related(srcs, src_type, rel_type, target_type, reverse=False):
             Filter("revoked", "=", False),
         ],
     )
+
+    relationships_dict = OrderedDict()
+    for relationship in relationships_with_dups:
+        if relationship["id"] not in relationships_dict:
+            relationships_dict[relationship["id"]] = relationship
+
+    relationships = relationships_dict.values()
 
     # stix_id => [ ids of objects with relationships with stix_id ]
     id_to_related = {}


### PR DESCRIPTION
Adds Mobile switch to data sources sidebar.

Adds a message on data source page when all techniques are hidden due to domain selected. This somewhat mitigates the problem that can occur when the user selects a data source and then changes the domain in the sidebar. Instead of just getting a blank area under the Data Components heading, they now get a short message explaining why there are no techniques listed.

There is still one issue with the domains that isn't addressed. The References at the bottom of the page are always the full set of references for all the data components/techniques, whether they are displayed or not. Fixing this will likely require a larger set of changes so has been deferred until later.

Closes #404 
