### PR TITLE
428 remove redirections to collaborate.mitre.org

### DIFF
--- a/modules/redirections/redirections.json
+++ b/modules/redirections/redirections.json
@@ -245,11 +245,6 @@
         "to": "/resources/versions/"
     },
     {
-        "title": "ics",
-        "from": "ics", 
-        "to": "https://collaborate.mitre.org/attackics"
-    },
-    {
         "title": "attack-matrix-poster-2018",
         "from": "docs/MITRE_ATTACK_Enterprise_Poster_2018.pdf", 
         "to": "/docs/attack_matrix_poster_2018.pdf"


### PR DESCRIPTION
## Description of what has changed

Removes the following redirection:

```
{
    "title": "ics",
    "from": "ics", 
    "to": "https://collaborate.mitre.org/attackics"
}
```

Requests to https://attack.mitre.org/ics will now yield a 404 error. This has been tested on Nginx.

## Issues addressed by pull request
Closes #428 