### PR TITLE
Fix Search Again

### DIFF
--- a/attack-search/__tests__/search-service.test.js
+++ b/attack-search/__tests__/search-service.test.js
@@ -52,6 +52,24 @@ describe('SearchService', () => {
         expect(tableResults).toEqual(data);
     });
 
+    test('Waits for FlexSearch indexing before backing up the search index', async () => {
+        let resolveAddBulk;
+        searchService.attackIndex.addBulk = jest.fn(() => new Promise((resolve) => {
+            resolveAddBulk = resolve;
+        }));
+        searchService.backupSearchIndex = jest.fn(() => Promise.resolve());
+
+        const initialization = searchService.initializeAsync(data);
+        await Promise.resolve();
+
+        expect(searchService.backupSearchIndex).not.toHaveBeenCalled();
+
+        resolveAddBulk();
+        await initialization;
+
+        expect(searchService.backupSearchIndex).toHaveBeenCalled();
+    });
+
     test('Backup search index completes when FlexSearch exports fewer than nine persisted chunks', async () => {
         const exportedChunks = [
             ['title.1.map', 'title map data'],

--- a/attack-search/src/search-service.js
+++ b/attack-search/src/search-service.js
@@ -166,7 +166,7 @@ module.exports = class SearchService {
       this.maxSearchResults = searchableDocuments.length;
 
       // Add the data to the in-memory FlexSearch instance
-      this.attackIndex.addBulk(searchableDocuments);
+      await this.attackIndex.addBulk(searchableDocuments);
 
       console.debug('Backing up search index...');
 

--- a/attack-search/src/settings.js
+++ b/attack-search/src/settings.js
@@ -1,7 +1,7 @@
 const baseURL = ''; // TODO migrate from base_url (generated via Pelican)
 const packageJson = require('../package.json');
 
-const searchCacheSchemaVersion = 2;
+const searchCacheSchemaVersion = 3;
 const flexSearchVersion = packageJson.dependencies.flexsearch.replace(/^[^\d]*/, '');
 const searchCacheCompatibilityVersion = `flexsearch-${flexSearchVersion}`;
 


### PR DESCRIPTION
This pull request improves the reliability of the search index backup process by ensuring that the backup only occurs after FlexSearch has finished indexing all documents. It also updates the search cache schema version to reflect this behavioral change. The most important changes are:

**Search Index Initialization and Backup:**

* Modified `SearchService.initializeAsync` in `search-service.js` to `await` the completion of `attackIndex.addBulk` before starting the backup, ensuring that the search index is fully built before backup begins.

**Testing Improvements:**

* Added a test in `search-service.test.js` to verify that the backup process waits for FlexSearch indexing to complete before running.

**Versioning:**

* Incremented the `searchCacheSchemaVersion` from 2 to 3 in `settings.js` to indicate a breaking change in the search cache logic.