### PR TITLE
fix(search): bulkPut hangs instead of rejecting when an IndexedDB write fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Website Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* Settle the search index write when an IndexedDB write fails, instead of leaving the promise pending and the search spinner up.
+
 ## v5.0.0 (2026-08-06)
 
 * Release ATT&CK content version 19.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 * Settle the search index write when an IndexedDB write fails, instead of leaving the promise pending and the search spinner up.
-* Disable the search controls and explain why when the search index cannot be built, instead of leaving the spinner running for as long as the page is open.
+* Disable the search controls and explain why when the search index cannot be built, instead of leaving the spinner running for as long as the page is open. A failed restore from the cached index is no longer reported as a successful load.
 
 ## v5.0.0 (2026-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * Settle the search index write when an IndexedDB write fails, instead of leaving the promise pending and the search spinner up.
+* Disable the search controls and explain why when the search index cannot be built, instead of leaving the spinner running for as long as the page is open.
 
 ## v5.0.0 (2026-08-06)
 

--- a/attack-search/__tests__/indexed-db-wrapper.test.js
+++ b/attack-search/__tests__/indexed-db-wrapper.test.js
@@ -57,4 +57,29 @@ describe('IndexedDBWrapper', () => {
         const count = await contentDb.count();
         expect(count).toEqual(data.length);
     });
+
+    // A failed write must settle the promise. Racing against a sentinel tells a
+    // rejection apart from a promise that never settles at all, which a plain
+    // rejects assertion cannot do: it would time out and look like a slow test.
+    const settle = (promise) => Promise.race([
+        promise.then(() => 'resolved', (error) => `rejected:${error.message}`),
+        new Promise((resolve) => setTimeout(() => resolve('HUNG'), 1000)),
+    ]);
+
+    test('Bulk put rejects when the underlying write fails', async () => {
+        jest.spyOn(contentDb.indexeddb[contentDb.tableName], 'bulkPut')
+            .mockRejectedValue(new Error('QuotaExceededError'));
+
+        await expect(settle(contentDb.bulkPut(data))).resolves.toBe('rejected:QuotaExceededError');
+    });
+
+    test('Bulk put rejects when a later chunk fails', async () => {
+        let calls = 0;
+        jest.spyOn(contentDb.indexeddb[contentDb.tableName], 'bulkPut')
+            .mockImplementation(() => (++calls === 2
+                ? Promise.reject(new Error('DatabaseClosedError'))
+                : Promise.resolve()));
+
+        await expect(settle(contentDb.bulkPut(data, 1))).resolves.toBe('rejected:DatabaseClosedError');
+    });
 });

--- a/attack-search/__tests__/search-events.test.js
+++ b/attack-search/__tests__/search-events.test.js
@@ -128,6 +128,15 @@ describe('search event bindings', () => {
     expect(parsingIcon.hide).toHaveBeenCalled();
   });
 
+  test('a failed restore from the cache is not reported as a successful load', async () => {
+    await loadIndexWithAFailingWarmRestore();
+
+    // The catch used to set the loaded flag false and the finally set it straight back to
+    // true, so `search` went on to query an index that was never populated.
+    expect(mockJqueryApis['#search-input'].prop).toHaveBeenCalledWith('disabled', true);
+    expect(mockJqueryApis['#search-icon'].addClass).toHaveBeenCalledWith('error-icon');
+  });
+
   test('a failed index build puts the search controls into their unavailable state', async () => {
     await loadIndexWithAFailingColdStart();
 
@@ -152,6 +161,24 @@ async function loadIndexWithAFailingColdStart() {
   jest.doMock('../src/debouncer.js', () => class {
     debounce(callback) {
       callback();
+    }
+  });
+
+  require('../src/index');
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+// Load the module on the cached path, with restoring the index from IndexedDB failing.
+async function loadIndexWithAFailingWarmRestore() {
+  const { searchCacheCompatibilityVersion, searchCacheSchemaVersion } = require('../src/settings');
+  const version = `${searchCacheSchemaVersion}-${searchCacheCompatibilityVersion}`;
+
+  global.window = { indexedDB: {} };
+  global.localStorage.getItem.mockReturnValue(`${global.build_uuid}-search-${version}`);
+
+  jest.doMock('../src/search-service.js', () => class {
+    initializeAsync() {
+      return Promise.reject(new Error('cached index is unreadable'));
     }
   });
 

--- a/attack-search/__tests__/search-events.test.js
+++ b/attack-search/__tests__/search-events.test.js
@@ -112,7 +112,52 @@ describe('search event bindings', () => {
     expect(mockJqueryApis['[data-search-filter-dropdown="core"]'].attr)
       .toHaveBeenCalledWith('aria-hidden', 'false');
   });
+
+  test('a failed index build stops search from waiting for an index that never arrives', async () => {
+    await loadIndexWithAFailingColdStart();
+
+    const parsingIcon = mockJqueryApis['#search-parsing-icon'];
+    parsingIcon.show.mockClear();
+    parsingIcon.hide.mockClear();
+
+    handlerForSelector('#search-input')({ target: { value: 'mimikatz' } });
+
+    // Before the fix `search` looped on the loaded flag, so it showed the parsing icon on
+    // its first pass and kept doing so every 100ms for as long as the page stayed open.
+    expect(parsingIcon.show).not.toHaveBeenCalled();
+    expect(parsingIcon.hide).toHaveBeenCalled();
+  });
+
+  test('a failed index build puts the search controls into their unavailable state', async () => {
+    await loadIndexWithAFailingColdStart();
+
+    expect(mockJqueryApis['#search-input'].prop).toHaveBeenCalledWith('disabled', true);
+    expect(mockJqueryApis['#search-button'].prop).toHaveBeenCalledWith('disabled', true);
+    expect(mockJqueryApis['#search-icon'].removeClass).toHaveBeenCalledWith('search-icon');
+    expect(mockJqueryApis['#search-icon'].addClass).toHaveBeenCalledWith('error-icon');
+    expect(mockJqueryApis['#search-button'].prop)
+      .toHaveBeenCalledWith('title', expect.stringContaining('search index could not be built'));
+  });
 });
+
+// Load the module on the cold-start path with the document fetch failing, and run the
+// debouncer straight through so the input handler reaches `search` without a timer.
+async function loadIndexWithAFailingColdStart() {
+  global.window = { indexedDB: {} };
+  global.localStorage.getItem.mockReturnValue(null);
+
+  jest.doMock('../src/search-loader.js', () => ({
+    loadSearchDocuments: () => Promise.reject(new Error('documents unavailable')),
+  }));
+  jest.doMock('../src/debouncer.js', () => class {
+    debounce(callback) {
+      callback();
+    }
+  });
+
+  require('../src/index');
+  await new Promise(resolve => setImmediate(resolve));
+}
 
 function eventsForSelector(selector) {
   return mockJqueryCalls

--- a/attack-search/src/index.js
+++ b/attack-search/src/index.js
@@ -89,6 +89,23 @@ const closeSearch = function () {
 // Variable to check if search service is loaded
 let searchServiceIsLoaded = false;
 
+// Set once the index cannot be built at all. Without it `search` waits for a flag that is
+// never going to flip and the parsing spinner runs for as long as the page is open.
+let searchServiceUnavailable = false;
+
+// Put the search controls into their unavailable state and explain why on hover.
+function markSearchUnavailable(reason) {
+  searchServiceUnavailable = true;
+  searchServiceIsLoaded = false;
+  searchInput.prop('disabled', true);
+  searchButton.prop('disabled', true);
+  searchIcon.removeClass('search-icon');
+  searchIcon.addClass('error-icon');
+  searchButton.prop('title', reason);
+}
+
+const SEARCH_INDEX_FAILED_MESSAGE = 'The search index could not be built. Reload the page to try again.';
+
 // Initialize the search service
 async function initializeSearchService() {
   console.debug('Initializing search service...');
@@ -111,12 +128,12 @@ async function initializeSearchService() {
         await searchService.initializeAsync(null); // Passing null will instruct the search service to attempt
         // restoring itself from the IndexedDB
         console.debug('SearchService is initialized.');
+        searchServiceIsLoaded = true;
       } catch (error) {
         console.error('Failed to initialize SearchService:', error);
-        searchServiceIsLoaded = false;
+        markSearchUnavailable(SEARCH_INDEX_FAILED_MESSAGE);
       } finally {
         searchParsingIcon.hide();
-        searchServiceIsLoaded = true;
       }
     }
     else {
@@ -139,18 +156,14 @@ async function initializeSearchService() {
         .catch(error => {
           console.error('Failed to initialize SearchService:', error);
           searchParsingIcon.hide();
-          searchServiceIsLoaded = false;
+          markSearchUnavailable(SEARCH_INDEX_FAILED_MESSAGE);
         });
     }
   }
   else {
     // Disable the search button and display an error icon with a hover effect that displays a message/explanation
     console.error('Search is only available in browsers that support IndexedDB. Please try using Firefox, Chrome, Safari, or another browser that supports IndexedDB.');
-    searchInput.prop('disabled', true);
-    searchButton.prop('disabled', true);
-    searchIcon.removeClass('search-icon');
-    searchIcon.addClass('error-icon');
-    searchButton.prop('title', 'To use the search feature, please make sure your browser supports IndexedDB. If not, consider upgrading your browser or switching to a supported browser such as Firefox, Chrome, or Safari.')
+    markSearchUnavailable('To use the search feature, please make sure your browser supports IndexedDB. If not, consider upgrading your browser or switching to a supported browser such as Firefox, Chrome, or Safari.');
   }
 }
 
@@ -158,11 +171,16 @@ async function initializeSearchService() {
 const search = async function (query) {
   console.debug(`search -> Received search query: ${query}`);
 
-  // Wait until the search service is loaded
-  while (!searchServiceIsLoaded) {
+  // Wait until the search service is loaded, or until we know it never will be.
+  while (!searchServiceIsLoaded && !searchServiceUnavailable) {
     console.debug('search -> search index is not loaded...');
     searchParsingIcon.show();
     await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  if (searchServiceUnavailable) {
+    searchParsingIcon.hide();
+    return;
   }
 
   console.debug(`Executing search: ${query}`);

--- a/attack-search/src/indexed-db-wrapper.js
+++ b/attack-search/src/indexed-db-wrapper.js
@@ -23,7 +23,7 @@ class TableWrapper {
      */
     async bulkPut(data, chunkSize = 100) {
 
-        return new Promise(async (resolve) => {
+        return new Promise((resolve, reject) => {
             /**
              * Schedules work using requestIdleCallback if supported, or setTimeout as a fallback.
              * @param {Function} callback - The function to be executed when the browser is idle or after the specified delay.
@@ -44,23 +44,28 @@ class TableWrapper {
              * @param {number} start - The index of the first item in the data array to be included in the current chunk.
              */
             const putChunk = async (start) => {
-                // If all data has been processed, resolve the promise
-                if (start >= data.length) {
-                    resolve();
-                    return;
+                try {
+                    // If all data has been processed, resolve the promise
+                    if (start >= data.length) {
+                        resolve();
+                        return;
+                    }
+
+                    // Determine the end index for the current chunk
+                    const end = Math.min(start + chunkSize, data.length);
+
+                    // Extract the chunk from the data array
+                    const chunk = data.slice(start, end);
+
+                    // Insert the chunk into the IndexedDB table
+                    await this.indexeddb[this.tableName].bulkPut(chunk);
+
+                    // Schedule the next chunk to be processed
+                    scheduleWork(() => putChunk(end));
+                } catch (error) {
+                    // Nothing else settles this promise, so callers would wait forever.
+                    reject(error);
                 }
-
-                // Determine the end index for the current chunk
-                const end = Math.min(start + chunkSize, data.length);
-
-                // Extract the chunk from the data array
-                const chunk = data.slice(start, end);
-
-                // Insert the chunk into the IndexedDB table
-                await this.indexeddb[this.tableName].bulkPut(chunk);
-
-                // Schedule the next chunk to be processed
-                scheduleWork(() => putChunk(end));
             };
 
             // Start processing the data array by inserting the first chunk


### PR DESCRIPTION
## Description of what has changed

`TableWrapper.bulkPut` ran its work inside `new Promise(async (resolve) => ...)` with no `reject`, and the chunk write at `indexed-db-wrapper.js:60` was unguarded. When Dexie rejects there (QuotaExceededError, DatabaseClosedError, an aborted transaction) the rejection settled the executor's own throwaway promise, so the promise returned to the caller never settled at all. It hung rather than rejected.

That matters because `SearchService.initializeAsync` awaits it on the cold-cache path, and `index.js:162` then spins on `while (!searchServiceIsLoaded)` with the parsing spinner shown. The `.catch` already written for that path at `index.js:139` could not run, because nothing ever rejected.

The fix takes `reject` and wraps the chunk loop in try/catch, following the shape already used in `backupSearchIndex`. Dropping `async` from the executor also clears `no-async-promise-executor`, which this repo's eslint config sets to error: one problem at line 26 before, none after.

Two tests added to the existing file. They race the call against a 1s sentinel so a hang is distinguishable from a rejection; a plain `rejects` assertion would just time out and read as a slow test. Both report `Received: "HUNG"` before the change and pass after. Full suite: 44 passing.

`CHANGELOG.md` has an `Unreleased` section for this. There was no pending heading, so please fold it into whichever version you cut next.

## Issues addressed by pull request

None open that I could find; the failure is silent, so it would surface as "search never finishes loading" rather than an error.

@isaisabel for review, per the template.
